### PR TITLE
Fix Order of `@tailwind` Directives

### DIFF
--- a/docs/rules/no-unknown-class.md
+++ b/docs/rules/no-unknown-class.md
@@ -337,8 +337,8 @@ which is equivalent to specifying this stylesheet:
 
 ```css
 @tailwind base;
-@tailwind utilities;
 @tailwind components;
+@tailwind utilities;
 ```
 
 ---
@@ -349,8 +349,8 @@ Using the following stylesheet:
 /* styles.css */
 
 @tailwind base;
-@tailwind utilities;
 @tailwind components;
+@tailwind utilities;
 
 @layer components {
   .some-component {

--- a/lib/util/get-classes.ts
+++ b/lib/util/get-classes.ts
@@ -8,8 +8,8 @@ import path from "path";
 
 const DEFAULT_INPUT_STYLE_SHEET = `
   @tailwind base;
-  @tailwind utilities;
   @tailwind components;
+  @tailwind utilities;
 `;
 
 const DEFAULT_INPUT_CHANGED = new Date();

--- a/tests/fixtures/no-unknown-class/postcss-config/styles.css
+++ b/tests/fixtures/no-unknown-class/postcss-config/styles.css
@@ -1,5 +1,5 @@
 @import "./components.css";
 
 @tailwind base;
-@tailwind utilities;
 @tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
Fix the order of `@tailwind` directives in:

- default input stylesheet
- test fixture for PostCSS config
- rule documentation